### PR TITLE
#54 wire add/remove/complete and save flow on planning page

### DIFF
--- a/backend/src/main/java/com/studyplanner/dto/StudyPlanResponse.java
+++ b/backend/src/main/java/com/studyplanner/dto/StudyPlanResponse.java
@@ -9,7 +9,7 @@ import lombok.Builder;
 public record StudyPlanResponse(
     @NotNull UUID externalId,
     String name,
-    @NotNull Integer completedCredits,
+    @NotNull Double completedCredits,
     @NotNull LocalDateTime startDate,
     @NotNull CurriculumResponse curriculum,
     @NotNull LocalDateTime creationDate) {}

--- a/backend/src/main/java/com/studyplanner/entity/StudyPlan.java
+++ b/backend/src/main/java/com/studyplanner/entity/StudyPlan.java
@@ -25,7 +25,7 @@ public class StudyPlan extends BaseEntity {
   @Column private String name;
 
   @Column(nullable = false)
-  private Integer completedCredits = 0;
+  private Double completedCredits = 0.0;
 
   @Column(nullable = false)
   private LocalDateTime startDate;
@@ -45,14 +45,13 @@ public class StudyPlan extends BaseEntity {
 
   public void recalculateCompletedCredits(Collection<PlannedCourse> plannedCourses) {
     if (plannedCourses == null || plannedCourses.isEmpty()) {
-      this.completedCredits = 0;
+      this.completedCredits = 0.0;
       return;
     }
     this.completedCredits =
-        (int)
-            plannedCourses.stream()
-                .filter(plannedCourse -> plannedCourse.getStatus() == CourseStatus.COMPLETED)
-                .mapToDouble(plannedCourse -> plannedCourse.getCourse().getCredits())
-                .sum();
+        plannedCourses.stream()
+            .filter(plannedCourse -> plannedCourse.getStatus() == CourseStatus.COMPLETED)
+            .mapToDouble(plannedCourse -> plannedCourse.getCourse().getCredits())
+            .sum();
   }
 }

--- a/backend/src/main/java/com/studyplanner/entity/StudyPlan.java
+++ b/backend/src/main/java/com/studyplanner/entity/StudyPlan.java
@@ -2,6 +2,7 @@ package com.studyplanner.entity;
 
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -41,4 +42,17 @@ public class StudyPlan extends BaseEntity {
   private List<Semester> semesters;
 
   @Column private LocalDateTime updateDate;
+
+  public void recalculateCompletedCredits(Collection<PlannedCourse> plannedCourses) {
+    if (plannedCourses == null || plannedCourses.isEmpty()) {
+      this.completedCredits = 0;
+      return;
+    }
+    this.completedCredits =
+        (int)
+            plannedCourses.stream()
+                .filter(plannedCourse -> plannedCourse.getStatus() == CourseStatus.COMPLETED)
+                .mapToDouble(plannedCourse -> plannedCourse.getCourse().getCredits())
+                .sum();
+  }
 }

--- a/backend/src/main/java/com/studyplanner/service/PlannedCourseService.java
+++ b/backend/src/main/java/com/studyplanner/service/PlannedCourseService.java
@@ -57,6 +57,7 @@ public class PlannedCourseService {
     plannedCourseRepository.saveAll(plannedCourses);
 
     semestersByExternalId.values().forEach(semesterService::recalculateAndSave);
+    studyPlanService.recalculateAndSave(studyPlan, plannedCourses);
 
     return PlannedCourseMapper.mapToResponseList(plannedCourses);
   }

--- a/backend/src/main/java/com/studyplanner/service/StudyPlanService.java
+++ b/backend/src/main/java/com/studyplanner/service/StudyPlanService.java
@@ -1,15 +1,18 @@
 package com.studyplanner.service;
 
 import com.studyplanner.dto.StudyPlanResponse;
+import com.studyplanner.entity.PlannedCourse;
 import com.studyplanner.entity.StudyPlan;
 import com.studyplanner.exception.ResourceNotFoundException;
 import com.studyplanner.mapper.StudyPlanMapper;
 import com.studyplanner.repository.StudyPlanRepository;
 import com.studyplanner.utils.UserRequestContext;
+import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -30,5 +33,11 @@ public class StudyPlanService {
     UUID userExternalId = UserRequestContext.getUserExternalId();
     return StudyPlanMapper.mapToResponseList(
         studyPlanRepository.findAllByUserExternalId(userExternalId));
+  }
+
+  @Transactional
+  public void recalculateAndSave(StudyPlan studyPlan, Collection<PlannedCourse> plannedCourses) {
+    studyPlan.recalculateCompletedCredits(plannedCourses);
+    studyPlanRepository.save(studyPlan);
   }
 }

--- a/backend/src/main/resources/db/changelog/changelog-1.xml
+++ b/backend/src/main/resources/db/changelog/changelog-1.xml
@@ -130,4 +130,11 @@
         </sql>
     </changeSet>
 
+    <changeSet id="28.04.2026" author="kaspar.kinko">
+        <sql>
+            ALTER TABLE study_plans ALTER COLUMN completed_credits TYPE DOUBLE PRECISION;
+            ALTER TABLE study_plans ALTER COLUMN completed_credits SET DEFAULT 0;
+        </sql>
+    </changeSet>
+
 </databaseChangeLog>

--- a/backend/src/main/resources/db/data-insert.sql
+++ b/backend/src/main/resources/db/data-insert.sql
@@ -8,7 +8,12 @@ INSERT INTO study_plans (curriculum_id, user_id, start_date) VALUES
     (1, 1, '2025-09-01 00:00:00');
 
 INSERT INTO semesters(finished, semester_type, study_plan_id, year) VALUES
-    (false, 'AUTUMN', 1, 2026);
+    (false, 'AUTUMN', 1, 2025),
+    (false, 'SPRING', 1, 2026),
+    (false, 'AUTUMN', 1, 2026),
+    (false, 'SPRING', 1, 2027),
+    (false, 'AUTUMN', 1, 2027),
+    (false, 'SPRING', 1, 2028);
 
 INSERT INTO modules (module_external_id, title, required_credits, optional_credits) VALUES
     ('49fa7f06-6752-6a70-134e-f6e2a869e2f6', 'Füüsika esimene suunamoodul', 24, 0);

--- a/backend/src/test/java/com/studyplanner/common/UnitTestFixtures.java
+++ b/backend/src/test/java/com/studyplanner/common/UnitTestFixtures.java
@@ -182,7 +182,7 @@ public class UnitTestFixtures {
   public static StudyPlan aStudyPlan() {
     return StudyPlan.builder()
         .externalId(A_STUDY_PLAN_EXTERNAL_ID)
-        .completedCredits(36)
+        .completedCredits(36.0)
         .user(aUser())
         .curriculum(aCurriculum())
         .creationDate(A_LOCAL_DATE_TIME)
@@ -211,7 +211,7 @@ public class UnitTestFixtures {
   public static StudyPlanResponse aStudyPlanResponse() {
     return StudyPlanResponse.builder()
         .externalId(A_STUDY_PLAN_EXTERNAL_ID)
-        .completedCredits(36)
+        .completedCredits(36.0)
         .curriculum(aCurriculumResponse())
         .creationDate(A_LOCAL_DATE_TIME)
         .build();

--- a/backend/src/test/java/com/studyplanner/service/PlannedCourseServiceTest.java
+++ b/backend/src/test/java/com/studyplanner/service/PlannedCourseServiceTest.java
@@ -3,7 +3,9 @@ package com.studyplanner.service;
 import static com.studyplanner.common.UnitTestFixtures.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import com.studyplanner.client.OisClient;
@@ -102,6 +104,30 @@ class PlannedCourseServiceTest {
           A_STUDY_PLAN_EXTERNAL_ID, List.of(aPlannedCourseRequest(CourseStatus.COMPLETED)));
 
       verify(semesterService).recalculateAndSave(any(Semester.class));
+    }
+  }
+
+  @Test
+  void shouldRecalculateCompletedCreditsAfterSave() {
+    var studyPlan = aStudyPlan();
+
+    try (var mockedRequestContext = mockStatic(UserRequestContext.class)) {
+      mockedRequestContext
+          .when(UserRequestContext::getUserExternalId)
+          .thenReturn(A_USER_EXTERNAL_ID);
+
+      when(studyPlanService.fetchStudyPlanById(A_STUDY_PLAN_EXTERNAL_ID)).thenReturn(studyPlan);
+      when(semesterService.fetchSemestersByStudyPlanExternalId(A_STUDY_PLAN_EXTERNAL_ID))
+          .thenReturn(List.of(aSemester()));
+      when(courseService.fetchCoursesByVersionExternalIds(any())).thenReturn(List.of(aCourse()));
+      when(moduleService.fetchModulesByCourseIds(any())).thenReturn(List.of(aModule()));
+      when(moduleService.fetchModuleByTitleAndCurriculumExternalId(any(), any()))
+          .thenReturn(aModule("Vabaained"));
+
+      plannedCourseService.setPlannedCourses(
+          A_STUDY_PLAN_EXTERNAL_ID, List.of(aPlannedCourseRequest(CourseStatus.COMPLETED)));
+
+      verify(studyPlanService).recalculateAndSave(eq(studyPlan), anyCollection());
     }
   }
 

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -5,6 +5,8 @@ services:
       target: dev
     container_name: frontend-dev
     command: npm start -- --host 0.0.0.0
+    environment:
+      BACKEND_URL: http://backend-dev:8080
     ports:
       - 4200:4200
     develop:

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -63,6 +63,9 @@
         },
         "serve": {
           "builder": "@angular/build:dev-server",
+          "options": {
+            "allowedHosts": ["localhost"]
+          },
           "configurations": {
             "production": {
               "buildTarget": "studyplanner:build:production"

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -530,8 +530,8 @@
             "type": "string"
           },
           "completedCredits": {
-            "type": "integer",
-            "format": "int32"
+            "type": "number",
+            "format": "double"
           },
           "startDate": {
             "type": "string",

--- a/frontend/src/app/features/curriculums/curriculum-planning/add-course-plan-dialog/add-course-plan-dialog.css
+++ b/frontend/src/app/features/curriculums/curriculum-planning/add-course-plan-dialog/add-course-plan-dialog.css
@@ -1,5 +1,5 @@
 .dialog {
-  background: var(--color-table-background, #fff);
+  background: var(--color-table-background);
   border-radius: 12px;
   padding: 24px;
   width: 320px;
@@ -7,7 +7,7 @@
   display: flex;
   flex-direction: column;
   gap: 16px;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.16);
+  box-shadow: 0 8px 24px var(--color-overlay-shadow);
 }
 
 .dialog__header {
@@ -66,7 +66,7 @@
   border-radius: 8px;
   font-size: 14px;
   font-weight: 600;
-  background: var(--color-table-background, #fff);
+  background: var(--color-table-background);
   cursor: pointer;
 }
 

--- a/frontend/src/app/features/curriculums/curriculum-planning/add-course-plan-dialog/add-course-plan-dialog.css
+++ b/frontend/src/app/features/curriculums/curriculum-planning/add-course-plan-dialog/add-course-plan-dialog.css
@@ -1,0 +1,106 @@
+.dialog {
+  background: var(--color-table-background, #fff);
+  border-radius: 12px;
+  padding: 24px;
+  width: 320px;
+  max-width: 90vw;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.16);
+}
+
+.dialog__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.dialog__label {
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--color-section-title);
+}
+
+.dialog__close {
+  background: none;
+  border: none;
+  font-size: 22px;
+  line-height: 1;
+  cursor: pointer;
+  color: var(--color-light-text);
+  padding: 0;
+}
+
+.dialog__close:hover {
+  color: var(--color-page-title);
+}
+
+.dialog__course-title {
+  font-family: 'Lexend', system-ui, sans-serif;
+  font-size: 22px;
+  font-weight: 700;
+  margin: 0;
+  color: var(--color-page-title);
+}
+
+.dialog__field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.dialog__field-label {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--color-light-text);
+}
+
+.dialog__select {
+  padding: 12px 14px;
+  border: 1px solid var(--color-divider);
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  background: var(--color-table-background, #fff);
+  cursor: pointer;
+}
+
+.dialog__select:focus {
+  outline: none;
+  border-color: var(--color-button);
+}
+
+.dialog__no-options {
+  padding: 12px 14px;
+  border-radius: 8px;
+  background: var(--color-sidebar-background);
+  font-size: 13px;
+  color: var(--color-light-text);
+}
+
+.dialog__submit {
+  background: var(--color-button);
+  color: var(--color-button-text);
+  border: none;
+  border-radius: 8px;
+  padding: 14px 20px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  margin-top: 8px;
+  transition: background-color 120ms ease;
+}
+
+.dialog__submit:hover:not(:disabled) {
+  background: var(--color-button-hover);
+}
+
+.dialog__submit:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/frontend/src/app/features/curriculums/curriculum-planning/add-course-plan-dialog/add-course-plan-dialog.html
+++ b/frontend/src/app/features/curriculums/curriculum-planning/add-course-plan-dialog/add-course-plan-dialog.html
@@ -1,0 +1,48 @@
+<div class="dialog">
+  <header class="dialog__header">
+    <span class="dialog__label">{{ 'CurriculumPlanning.Add' | t }}</span>
+    <button
+      type="button"
+      class="dialog__close"
+      (click)="cancel()"
+      [attr.aria-label]="'Common.Close' | t"
+    >
+      ×
+    </button>
+  </header>
+
+  <h2 class="dialog__course-title">{{ data.course.titleEt }}</h2>
+
+  <div class="dialog__field">
+    <label class="dialog__field-label" for="semester-select">
+      {{ 'CurriculumPlanning.IntoSemester' | t }}
+    </label>
+    @if (data.semesters.length === 0) {
+      <span class="dialog__no-options">
+        {{ 'CurriculumPlanning.NoMatchingSemesters' | t }}
+      </span>
+    } @else {
+      <select
+        id="semester-select"
+        class="dialog__select"
+        [value]="selectedSemesterId()"
+        (change)="onSemesterChange($event)"
+      >
+        @for (semester of data.semesters; track semester.externalId) {
+          <option [value]="semester.externalId">
+            {{ semester.year }} {{ getSemesterKey(semester.semesterType ?? '') | t }}
+          </option>
+        }
+      </select>
+    }
+  </div>
+
+  <button
+    type="button"
+    class="dialog__submit"
+    (click)="confirm()"
+    [disabled]="data.semesters.length === 0 || !selectedSemesterId()"
+  >
+    {{ 'CurriculumPlanning.AddToPlan' | t }}
+  </button>
+</div>

--- a/frontend/src/app/features/curriculums/curriculum-planning/add-course-plan-dialog/add-course-plan-dialog.spec.ts
+++ b/frontend/src/app/features/curriculums/curriculum-planning/add-course-plan-dialog/add-course-plan-dialog.spec.ts
@@ -1,0 +1,90 @@
+import { TestBed } from '@angular/core/testing';
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
+import { it, expect, vi } from 'vitest';
+import { AddCoursePlanDialog, AddCoursePlanDialogData } from './add-course-plan-dialog';
+import { CourseResponse, SemesterResponse } from '@/client';
+
+const course: CourseResponse = {
+  externalId: 'c-1',
+  oisExternalId: 'ois-1',
+  versionExternalId: 'v-1',
+  titleEn: 'Higher Math',
+  titleEt: 'Kõrgem matemaatika',
+  code: 'MTAT.01',
+  credits: 6,
+  semesterType: CourseResponse.semesterType.AUTUMN,
+};
+
+const semesters: SemesterResponse[] = [
+  {
+    externalId: 's-1',
+    year: 2025,
+    finished: false,
+    semesterType: SemesterResponse.semesterType.AUTUMN,
+    creationDate: '2025-09-01T00:00:00Z',
+  },
+  {
+    externalId: 's-2',
+    year: 2026,
+    finished: false,
+    semesterType: SemesterResponse.semesterType.AUTUMN,
+    creationDate: '2026-09-01T00:00:00Z',
+  },
+];
+
+function setup(data: AddCoursePlanDialogData = { course, semesters }) {
+  const close = vi.fn();
+  TestBed.configureTestingModule({
+    providers: [
+      { provide: DIALOG_DATA, useValue: data },
+      { provide: DialogRef, useValue: { close } },
+    ],
+  });
+  const fixture = TestBed.createComponent(AddCoursePlanDialog);
+  fixture.detectChanges();
+  return { fixture, close };
+}
+
+it('renders course title and a select with all semesters', () => {
+  const { fixture } = setup();
+  const heading = fixture.nativeElement.querySelector('.dialog__course-title');
+  expect(heading.textContent.trim()).toBe('Kõrgem matemaatika');
+
+  const options = fixture.nativeElement.querySelectorAll('option');
+  expect(options.length).toBe(2);
+});
+
+it('closes with the first semester id when submit is clicked without changing selection', () => {
+  const { fixture, close } = setup();
+  const submit: HTMLButtonElement = fixture.nativeElement.querySelector('.dialog__submit');
+  submit.click();
+  expect(close).toHaveBeenCalledWith('s-1');
+});
+
+it('closes with the picked semester id after selection change', () => {
+  const { fixture, close } = setup();
+  const select: HTMLSelectElement = fixture.nativeElement.querySelector('.dialog__select');
+  select.value = 's-2';
+  select.dispatchEvent(new Event('change'));
+  fixture.detectChanges();
+
+  const submit: HTMLButtonElement = fixture.nativeElement.querySelector('.dialog__submit');
+  submit.click();
+  expect(close).toHaveBeenCalledWith('s-2');
+});
+
+it('closes with undefined when X is clicked', () => {
+  const { fixture, close } = setup();
+  const cancel: HTMLButtonElement = fixture.nativeElement.querySelector('.dialog__close');
+  cancel.click();
+  expect(close).toHaveBeenCalledWith(undefined);
+});
+
+it('disables submit and shows fallback message when no matching semesters', () => {
+  const { fixture } = setup({ course, semesters: [] });
+  const submit: HTMLButtonElement = fixture.nativeElement.querySelector('.dialog__submit');
+  expect(submit.disabled).toBe(true);
+
+  const fallback = fixture.nativeElement.querySelector('.dialog__no-options');
+  expect(fallback).not.toBeNull();
+});

--- a/frontend/src/app/features/curriculums/curriculum-planning/add-course-plan-dialog/add-course-plan-dialog.ts
+++ b/frontend/src/app/features/curriculums/curriculum-planning/add-course-plan-dialog/add-course-plan-dialog.ts
@@ -1,0 +1,42 @@
+import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
+import { CommonModule } from '@angular/common';
+import { TPipe } from '@/pipes';
+import { CourseResponse, SemesterResponse } from '@/client';
+import { getSemesterKey } from '@/utils';
+
+export interface AddCoursePlanDialogData {
+  course: CourseResponse;
+  semesters: SemesterResponse[];
+}
+
+@Component({
+  selector: 'app-add-course-plan-dialog',
+  imports: [CommonModule, TPipe],
+  templateUrl: './add-course-plan-dialog.html',
+  styleUrl: './add-course-plan-dialog.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AddCoursePlanDialog {
+  private readonly dialogRef = inject<DialogRef<string | undefined>>(DialogRef);
+  protected readonly data = inject<AddCoursePlanDialogData>(DIALOG_DATA);
+  protected readonly getSemesterKey = getSemesterKey;
+  protected readonly selectedSemesterId = signal<string>(
+    this.data.semesters[0]?.externalId ?? '',
+  );
+
+  protected onSemesterChange(event: Event): void {
+    const value = (event.target as HTMLSelectElement).value;
+    this.selectedSemesterId.set(value);
+  }
+
+  protected confirm(): void {
+    const id = this.selectedSemesterId();
+    if (!id) return;
+    this.dialogRef.close(id);
+  }
+
+  protected cancel(): void {
+    this.dialogRef.close(undefined);
+  }
+}

--- a/frontend/src/app/features/curriculums/curriculum-planning/add-course-plan-dialog/add-course-plan-dialog.ts
+++ b/frontend/src/app/features/curriculums/curriculum-planning/add-course-plan-dialog/add-course-plan-dialog.ts
@@ -21,9 +21,7 @@ export class AddCoursePlanDialog {
   private readonly dialogRef = inject<DialogRef<string | undefined>>(DialogRef);
   protected readonly data = inject<AddCoursePlanDialogData>(DIALOG_DATA);
   protected readonly getSemesterKey = getSemesterKey;
-  protected readonly selectedSemesterId = signal<string>(
-    this.data.semesters[0]?.externalId ?? '',
-  );
+  protected readonly selectedSemesterId = signal<string>(this.data.semesters[0]?.externalId ?? '');
 
   protected onSemesterChange(event: Event): void {
     const value = (event.target as HTMLSelectElement).value;

--- a/frontend/src/app/features/curriculums/curriculum-planning/curriculum-planning.css
+++ b/frontend/src/app/features/curriculums/curriculum-planning/curriculum-planning.css
@@ -146,7 +146,11 @@
 
 .planning__dot-slot {
   position: absolute;
-  transform: translateX(-150%);
+  left: -40px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 16px;
+  height: 16px;
 }
 
 .planning__current-dot {
@@ -154,7 +158,19 @@
   height: 16px;
   border-radius: 50%;
   background-color: var(--color-sidebar-background);
-  display: inline-block;
+  display: block;
+}
+
+.planning__chevron {
+  width: 12px;
+  height: 12px;
+  color: var(--color-light-text);
+  transition: transform 200ms ease;
+  flex-shrink: 0;
+}
+
+.planning__chevron--up {
+  transform: rotate(180deg);
 }
 
 .planning__semester-name {
@@ -247,4 +263,66 @@ td {
 .column__credits {
   width: 25%;
   text-align: center;
+}
+
+.planning__notice {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 14px;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.planning__notice--success {
+  background: #e8f5ed;
+  color: #1f6b3a;
+}
+
+.planning__notice--error {
+  background: #fdecec;
+  color: #a92626;
+}
+
+.planning__notice-close {
+  background: none;
+  border: none;
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  color: inherit;
+  padding: 0 4px;
+}
+
+.planning__row-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.planning__add-btn,
+.planning__remove-btn {
+  background: none;
+  border: none;
+  font-size: 18px;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 6px;
+  color: var(--color-section-title);
+  line-height: 1;
+}
+
+.planning__add-btn {
+  font-size: 20px;
+}
+
+.planning__add-btn:hover,
+.planning__remove-btn:hover {
+  background: var(--color-table-background);
+}
+
+.planning__remove-btn {
+  color: #a92626;
 }

--- a/frontend/src/app/features/curriculums/curriculum-planning/curriculum-planning.css
+++ b/frontend/src/app/features/curriculums/curriculum-planning/curriculum-planning.css
@@ -278,13 +278,13 @@ td {
 }
 
 .planning__notice--success {
-  background: #e8f5ed;
-  color: #1f6b3a;
+  background: var(--color-success-background);
+  color: var(--color-success-text);
 }
 
 .planning__notice--error {
-  background: #fdecec;
-  color: #a92626;
+  background: var(--color-error-background);
+  color: var(--color-error-text);
 }
 
 .planning__notice-close {
@@ -325,5 +325,5 @@ td {
 }
 
 .planning__remove-btn {
-  color: #a92626;
+  color: var(--color-error-text);
 }

--- a/frontend/src/app/features/curriculums/curriculum-planning/curriculum-planning.css
+++ b/frontend/src/app/features/curriculums/curriculum-planning/curriculum-planning.css
@@ -59,6 +59,7 @@
   flex-direction: column;
   gap: 16px;
   min-height: 400px;
+  padding-right: 12px;
 }
 
 .planning__panel--split {

--- a/frontend/src/app/features/curriculums/curriculum-planning/curriculum-planning.html
+++ b/frontend/src/app/features/curriculums/curriculum-planning/curriculum-planning.html
@@ -1,10 +1,34 @@
 <section class="planning">
   <header class="planning__header">
     <h1 class="planning__title">{{ 'CurriculumPlanning.Title' | t }}</h1>
-    <button type="button" class="planning__save" disabled>
-      {{ 'Common.Save' | t }}
+    <button
+      type="button"
+      class="planning__save"
+      (click)="save()"
+      [disabled]="!dirty() || saving()"
+    >
+      {{ (saving() ? 'Common.Saving' : 'Common.Save') | t }}
     </button>
   </header>
+
+  @if (notification(); as note) {
+    <div
+      class="planning__notice"
+      [class.planning__notice--success]="note.kind === 'success'"
+      [class.planning__notice--error]="note.kind === 'error'"
+      role="status"
+    >
+      <span>{{ note.key | t }}</span>
+      <button
+        type="button"
+        class="planning__notice-close"
+        (click)="dismissNotification()"
+        [attr.aria-label]="'Common.Close' | t"
+      >
+        ×
+      </button>
+    </div>
+  }
 
   <div class="planning__panels">
     <section class="planning__panel">
@@ -29,7 +53,9 @@
             <cdk-accordion-item
               #accordionItem="cdkAccordionItem"
               class="planning__accordion-item"
-              [expanded]="semester.externalId === currentSemesterId()"
+              [expanded]="
+                getCourses(semester).length > 0 || semester.externalId === currentSemesterId()
+              "
             >
               <button
                 class="planning__accordion-header"
@@ -43,39 +69,68 @@
                 </span>
                 <span
                   class="planning__semester-name"
-                  [class.planning__semester-name--done]="semester.finished"
+                  [class.planning__semester-name--done]="isSemesterFinished(semester.externalId)"
                 >
                   {{ getSemesterKey(semester.semesterType ?? '') | t }} {{ semester.year }}
                 </span>
                 <span
                   class="planning__credits"
-                  [class.planning__semester-name--done]="semester.finished"
+                  [class.planning__semester-name--done]="isSemesterFinished(semester.externalId)"
                 >
-                  {{ calculateSemesterCredits(semester.plannedCourses ?? []) }}/{{ 30 }}
+                  {{ getSemesterCredits(semester.externalId) }}/{{ 30 }}
                 </span>
                 <span
                   class="planning__credits-unit"
-                  [class.planning__semester-name--done]="semester.finished"
+                  [class.planning__semester-name--done]="isSemesterFinished(semester.externalId)"
                   >{{ 'CurriculumPlanning.Credits' | t }}</span
                 >
-                <span>
-                  {{ accordionItem.expanded ? '△' : '▽' }}
-                </span>
+                <svg
+                  class="planning__chevron"
+                  [class.planning__chevron--up]="accordionItem.expanded"
+                  viewBox="0 0 12 8"
+                  fill="none"
+                  aria-hidden="true"
+                >
+                  <path
+                    d="M1 1.5L6 6L11 1.5"
+                    stroke="currentColor"
+                    stroke-width="1.6"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
               </button>
 
               @if (accordionItem.expanded) {
-                <ng-template #checkboxTpl let-course>
-                  <input
-                    type="checkbox"
-                    class="course__checkbox"
-                    [checked]="course.courseStatus === 'COMPLETED'"
-                  />
+                <ng-template #plannedActionTpl let-course>
+                  <div class="planning__row-actions">
+                    <input
+                      type="checkbox"
+                      class="course__checkbox"
+                      [checked]="course.courseStatus === 'COMPLETED'"
+                      (change)="
+                        toggleCompleted(
+                          course.versionExternalId,
+                          semester.externalId,
+                          $any($event.target).checked
+                        )
+                      "
+                    />
+                    <button
+                      type="button"
+                      class="planning__remove-btn"
+                      (click)="removeCourse(course.versionExternalId, semester.externalId)"
+                      [attr.aria-label]="'CurriculumPlanning.RemoveCourse' | t"
+                    >
+                      ×
+                    </button>
+                  </div>
                 </ng-template>
 
                 <app-course-table
                   [courses]="getCourses(semester)"
                   [showHeader]="false"
-                  [actionTemplate]="checkboxTpl"
+                  [actionTemplate]="plannedActionTpl"
                 />
               }
             </cdk-accordion-item>
@@ -100,8 +155,19 @@
         @if (courses().length === 0) {
           <app-notification [message]="'CurriculumPlanning.NoCoursesNotification' | t" />
         } @else {
+          <ng-template #catalogActionTpl let-course>
+            <button
+              type="button"
+              class="planning__add-btn"
+              (click)="addCourse(course)"
+              [attr.aria-label]="'CurriculumPlanning.AddToPlan' | t"
+            >
+              +
+            </button>
+          </ng-template>
+
           <div class="planning__table-scroll">
-            <app-course-table [courses]="courses()" />
+            <app-course-table [courses]="courses()" [actionTemplate]="catalogActionTpl" />
           </div>
         }
       </div>

--- a/frontend/src/app/features/curriculums/curriculum-planning/curriculum-planning.html
+++ b/frontend/src/app/features/curriculums/curriculum-planning/curriculum-planning.html
@@ -1,12 +1,7 @@
 <section class="planning">
   <header class="planning__header">
     <h1 class="planning__title">{{ 'CurriculumPlanning.Title' | t }}</h1>
-    <button
-      type="button"
-      class="planning__save"
-      (click)="save()"
-      [disabled]="!dirty() || saving()"
-    >
+    <button type="button" class="planning__save" (click)="save()" [disabled]="!dirty() || saving()">
       {{ (saving() ? 'Common.Saving' : 'Common.Save') | t }}
     </button>
   </header>
@@ -36,18 +31,18 @@
         {{ 'CurriculumPlanning.SemesterPlan' | t }}
       </h2>
 
+      <label class="planning__hide-toggle">
+        <input
+          type="checkbox"
+          class="course__checkbox"
+          (change)="hideCompleted.set(!hideCompleted())"
+        />
+        {{ 'CurriculumPlanning.HideCompletedSemesters' | t }}
+      </label>
+
       @if (filteredSemesters().length === 0) {
         <app-notification [message]="'CurriculumPlanning.NoSemestersNotification' | t" />
       } @else {
-        <label class="planning__hide-toggle">
-          <input
-            type="checkbox"
-            class="course__checkbox"
-            (change)="hideCompleted.set(!hideCompleted())"
-          />
-          {{ 'CurriculumPlanning.HideCompletedSemesters' | t }}
-        </label>
-
         <cdk-accordion class="planning__accordion" [multi]="true">
           @for (semester of filteredSemesters(); track semester.externalId) {
             <cdk-accordion-item

--- a/frontend/src/app/features/curriculums/curriculum-planning/curriculum-planning.spec.ts
+++ b/frontend/src/app/features/curriculums/curriculum-planning/curriculum-planning.spec.ts
@@ -1,0 +1,202 @@
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+import { Dialog } from '@angular/cdk/dialog';
+import { of, Subject } from 'rxjs';
+import { it, expect, vi } from 'vitest';
+import {
+  CourseResponse,
+  CourseService,
+  CurriculumService,
+  ModuleService,
+  PlannedCourseRequest,
+  PlannedCourseResponse,
+  PlannedCourseService,
+  SemesterResponse,
+  SemesterService,
+  UserService,
+} from '@/client';
+import { CurriculumPlanning } from './curriculum-planning';
+
+const STUDY_PLAN_ID = 'sp-1';
+const USER = { externalId: 'u-1', name: 'Jane' };
+
+const SEMESTER_AUTUMN: SemesterResponse = {
+  externalId: 'sem-autumn',
+  year: 2026,
+  finished: false,
+  semesterType: SemesterResponse.semesterType.AUTUMN,
+  creationDate: '2026-09-01T00:00:00Z',
+  plannedCourses: [
+    {
+      externalId: 'pc-1',
+      course: {
+        externalId: 'c-1',
+        oisExternalId: 'ois-1',
+        versionExternalId: 'v-1',
+        titleEn: 'Mikro',
+        titleEt: 'Mikromaailma füüsika',
+        code: 'LOFY.01.009',
+        credits: 6,
+        semesterType: CourseResponse.semesterType.AUTUMN,
+      },
+      module: {
+        externalId: 'm-1',
+        title: 'Vabaained',
+        requiredCredits: 0,
+        optionalCredits: 6,
+      },
+      courseStatus: PlannedCourseResponse.courseStatus.PLANNED,
+    },
+  ],
+};
+
+const SEMESTER_SPRING: SemesterResponse = {
+  externalId: 'sem-spring',
+  year: 2027,
+  finished: false,
+  semesterType: SemesterResponse.semesterType.SPRING,
+  creationDate: '2027-02-01T00:00:00Z',
+  plannedCourses: [],
+};
+
+function setup() {
+  const semesterService = {
+    getSemesters: vi.fn().mockReturnValue(of([SEMESTER_AUTUMN, SEMESTER_SPRING])),
+  };
+  const userService = {
+    getAllUsers: vi.fn().mockReturnValue(of([USER])),
+  };
+  const courseService = {
+    getAllCourses: vi.fn().mockReturnValue(of([])),
+  };
+  const curriculumService = {
+    getCurriculumByStudyPlan: vi.fn().mockReturnValue(of({ credits: 120 })),
+  };
+  const moduleService = {
+    getModules: vi.fn().mockReturnValue(of([])),
+  };
+  const plannedCourseService = {
+    setPlannedCourses: vi.fn().mockReturnValue(of([])),
+  };
+  const dialogClosed$ = new Subject<string | undefined>();
+  const dialog = {
+    open: vi.fn().mockReturnValue({ closed: dialogClosed$.asObservable() }),
+  };
+
+  TestBed.configureTestingModule({
+    providers: [
+      { provide: ActivatedRoute, useValue: { snapshot: { params: { externalId: STUDY_PLAN_ID } } } },
+      { provide: UserService, useValue: userService },
+      { provide: CourseService, useValue: courseService },
+      { provide: CurriculumService, useValue: curriculumService },
+      { provide: ModuleService, useValue: moduleService },
+      { provide: SemesterService, useValue: semesterService },
+      { provide: PlannedCourseService, useValue: plannedCourseService },
+      { provide: Dialog, useValue: dialog },
+    ],
+  });
+
+  const fixture = TestBed.createComponent(CurriculumPlanning);
+  fixture.detectChanges();
+  return { fixture, plannedCourseService, dialog, dialogClosed$ };
+}
+
+const SPRING_COURSE: CourseResponse = {
+  externalId: undefined as unknown as string,
+  oisExternalId: 'ois-2',
+  versionExternalId: 'v-2',
+  titleEn: 'Algebra',
+  titleEt: 'Algebra',
+  code: 'MTAT.02',
+  credits: 4,
+  semesterType: CourseResponse.semesterType.SPRING,
+};
+
+it('hydrates draft from server semesters and is not dirty initially', () => {
+  const { fixture } = setup();
+  const cmp = fixture.componentInstance;
+  expect(cmp.draftPlannedCourses().length).toBe(1);
+  expect(cmp.dirty()).toBe(false);
+});
+
+it('opens the dialog with only matching-type semesters and adds to draft on confirm', () => {
+  const { fixture, dialog, dialogClosed$ } = setup();
+  const cmp = fixture.componentInstance;
+
+  cmp.addCourse(SPRING_COURSE);
+
+  expect(dialog.open).toHaveBeenCalledTimes(1);
+  const passed = dialog.open.mock.calls[0][1].data.semesters as SemesterResponse[];
+  expect(passed.map((s) => s.externalId)).toEqual(['sem-spring']);
+
+  dialogClosed$.next('sem-spring');
+
+  const draft = cmp.draftPlannedCourses();
+  expect(draft.length).toBe(2);
+  expect(draft.some((d) => d.course.versionExternalId === 'v-2')).toBe(true);
+  expect(cmp.dirty()).toBe(true);
+});
+
+it('shows error notification when the only matching semester already contains this course', () => {
+  const { fixture, dialog, dialogClosed$ } = setup();
+  const cmp = fixture.componentInstance;
+
+  cmp.addCourse(SPRING_COURSE);
+  dialogClosed$.next('sem-spring');
+
+  dialog.open.mockClear();
+  cmp.addCourse(SPRING_COURSE);
+
+  expect(dialog.open).not.toHaveBeenCalled();
+  expect(cmp.notification()).toEqual({
+    kind: 'error',
+    key: 'CurriculumPlanning.NoMatchingSemesters',
+  });
+});
+
+it('removes a draft course and toggles status', () => {
+  const { fixture } = setup();
+  const cmp = fixture.componentInstance;
+
+  cmp.toggleCompleted('v-1', 'sem-autumn', true);
+  expect(cmp.draftPlannedCourses()[0].status).toBe(
+    PlannedCourseResponse.courseStatus.COMPLETED,
+  );
+  expect(cmp.dirty()).toBe(true);
+
+  cmp.toggleCompleted('v-1', 'sem-autumn', false);
+  expect(cmp.draftPlannedCourses()[0].status).toBe(
+    PlannedCourseResponse.courseStatus.PLANNED,
+  );
+  expect(cmp.dirty()).toBe(false);
+
+  cmp.removeCourse('v-1', 'sem-autumn');
+  expect(cmp.draftPlannedCourses().length).toBe(0);
+  expect(cmp.dirty()).toBe(true);
+});
+
+it('serializes the full draft as PlannedCourseRequest[] on save', () => {
+  const { fixture, plannedCourseService } = setup();
+  const cmp = fixture.componentInstance;
+
+  cmp.toggleCompleted('v-1', 'sem-autumn', true);
+  cmp.save();
+
+  expect(plannedCourseService.setPlannedCourses).toHaveBeenCalledTimes(1);
+  const [studyPlanId, payload] = plannedCourseService.setPlannedCourses.mock.calls[0];
+  expect(studyPlanId).toBe(STUDY_PLAN_ID);
+  expect(payload).toEqual<PlannedCourseRequest[]>([
+    {
+      semesterExternalId: 'sem-autumn',
+      courseVersionExternalId: 'v-1',
+      courseExternalId: 'ois-1',
+      status: PlannedCourseRequest.status.COMPLETED,
+    },
+  ]);
+});
+
+it('does not call the service when not dirty', () => {
+  const { fixture, plannedCourseService } = setup();
+  fixture.componentInstance.save();
+  expect(plannedCourseService.setPlannedCourses).not.toHaveBeenCalled();
+});

--- a/frontend/src/app/features/curriculums/curriculum-planning/curriculum-planning.spec.ts
+++ b/frontend/src/app/features/curriculums/curriculum-planning/curriculum-planning.spec.ts
@@ -153,7 +153,7 @@ it('shows error notification when the only matching semester already contains th
   expect(dialog.open).not.toHaveBeenCalled();
   expect(cmp.notification()).toEqual({
     kind: 'error',
-    key: 'CurriculumPlanning.NoMatchingSemesters',
+    key: 'CurriculumPlanning.NoAvailableSemester',
   });
 });
 

--- a/frontend/src/app/features/curriculums/curriculum-planning/curriculum-planning.spec.ts
+++ b/frontend/src/app/features/curriculums/curriculum-planning/curriculum-planning.spec.ts
@@ -85,7 +85,10 @@ function setup() {
 
   TestBed.configureTestingModule({
     providers: [
-      { provide: ActivatedRoute, useValue: { snapshot: { params: { externalId: STUDY_PLAN_ID } } } },
+      {
+        provide: ActivatedRoute,
+        useValue: { snapshot: { params: { externalId: STUDY_PLAN_ID } } },
+      },
       { provide: UserService, useValue: userService },
       { provide: CourseService, useValue: courseService },
       { provide: CurriculumService, useValue: curriculumService },
@@ -159,15 +162,11 @@ it('removes a draft course and toggles status', () => {
   const cmp = fixture.componentInstance;
 
   cmp.toggleCompleted('v-1', 'sem-autumn', true);
-  expect(cmp.draftPlannedCourses()[0].status).toBe(
-    PlannedCourseResponse.courseStatus.COMPLETED,
-  );
+  expect(cmp.draftPlannedCourses()[0].status).toBe(PlannedCourseResponse.courseStatus.COMPLETED);
   expect(cmp.dirty()).toBe(true);
 
   cmp.toggleCompleted('v-1', 'sem-autumn', false);
-  expect(cmp.draftPlannedCourses()[0].status).toBe(
-    PlannedCourseResponse.courseStatus.PLANNED,
-  );
+  expect(cmp.draftPlannedCourses()[0].status).toBe(PlannedCourseResponse.courseStatus.PLANNED);
   expect(cmp.dirty()).toBe(false);
 
   cmp.removeCourse('v-1', 'sem-autumn');

--- a/frontend/src/app/features/curriculums/curriculum-planning/curriculum-planning.ts
+++ b/frontend/src/app/features/curriculums/curriculum-planning/curriculum-planning.ts
@@ -3,6 +3,7 @@ import {
   Component,
   computed,
   inject,
+  linkedSignal,
   Signal,
   signal,
 } from '@angular/core';
@@ -10,13 +11,16 @@ import { TPipe } from '@/pipes';
 import { CommonModule } from '@angular/common';
 import { CourseTable, Notification, Search } from '@/components';
 import { CdkAccordionModule } from '@angular/cdk/accordion';
+import { Dialog } from '@angular/cdk/dialog';
 import {
   CourseResponse,
   CourseService,
   CurriculumService,
   ModuleResponse,
   ModuleService,
+  PlannedCourseRequest,
   PlannedCourseResponse,
+  PlannedCourseService,
   SemesterResponse,
   SemesterService,
   UserResponse,
@@ -24,11 +28,28 @@ import {
 } from '@/client';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { catchError, filter, map, switchMap } from 'rxjs/operators';
-import { calculateSemesterCredits, findCurrentSemester, getSemesterKey } from '@/utils';
+import { combineLatest, of } from 'rxjs';
+import { findCurrentSemester, getSemesterKey } from '@/utils';
 import { ActivatedRoute } from '@angular/router';
-import { of } from 'rxjs';
+import {
+  AddCoursePlanDialog,
+  AddCoursePlanDialogData,
+} from './add-course-plan-dialog/add-course-plan-dialog';
 
 type CourseWithStatus = CourseResponse & { courseStatus: PlannedCourseResponse.courseStatus };
+
+interface DraftPlannedCourse {
+  externalId?: string;
+  semesterExternalId: string;
+  course: CourseResponse;
+  module?: ModuleResponse;
+  status: PlannedCourseResponse.courseStatus;
+}
+
+interface SaveNotification {
+  kind: 'success' | 'error';
+  key: string;
+}
 
 @Component({
   selector: 'app-curriculum-planning',
@@ -43,7 +64,9 @@ export class CurriculumPlanning {
   private readonly curriculumService = inject(CurriculumService);
   private readonly userService = inject(UserService);
   private readonly moduleService = inject(ModuleService);
+  private readonly plannedCourseService = inject(PlannedCourseService);
   private readonly route = inject(ActivatedRoute);
+  private readonly dialog = inject(Dialog);
   private readonly studyPlanExternalId = this.route.snapshot.params['externalId'];
 
   readonly user: Signal<UserResponse | null> = toSignal(
@@ -61,51 +84,63 @@ export class CurriculumPlanning {
 
   readonly courses = toSignal(this.courses$, { initialValue: [] });
 
-  protected readonly calculateSemesterCredits = calculateSemesterCredits;
   protected readonly getSemesterKey = getSemesterKey;
   readonly hideCompleted = signal(false);
 
+  private readonly refreshTrigger = signal(0);
+  readonly saving = signal(false);
+  readonly notification = signal<SaveNotification | null>(null);
+
   readonly semesters: Signal<SemesterResponse[]> = toSignal(
-    toObservable(this.user).pipe(
-      filter((user) => user !== null),
-      switchMap((user) =>
-        this.semesterService.getSemesters(this.studyPlanExternalId, user.externalId),
+    combineLatest([toObservable(this.user), toObservable(this.refreshTrigger)]).pipe(
+      filter(([user]) => user !== null),
+      switchMap(([user]) =>
+        this.semesterService.getSemesters(this.studyPlanExternalId, user!.externalId),
       ),
     ),
-    {
-      initialValue: [],
-    },
+    { initialValue: [] },
   );
 
-  getCourses(semester: SemesterResponse): CourseWithStatus[] {
-    return (
-      semester.plannedCourses?.map((pc) => ({
-        ...pc.course,
-        courseStatus: pc.courseStatus,
-      })) ?? []
-    );
-  }
+  readonly draftPlannedCourses = linkedSignal<DraftPlannedCourse[]>(() =>
+    this.flattenSemesters(this.semesters()),
+  );
+
+  private readonly initialPlannedCourses = linkedSignal<DraftPlannedCourse[]>(() =>
+    this.flattenSemesters(this.semesters()),
+  );
+
+  readonly dirty = computed(
+    () =>
+      this.serializeDraft(this.draftPlannedCourses()) !==
+      this.serializeDraft(this.initialPlannedCourses()),
+  );
 
   readonly sortedSemesters = computed(() =>
     [...this.semesters()].sort((a, b) => {
       if (a.year !== b.year) return a.year - b.year;
-      const order: Record<string, number> = { AUTUMN: 1, SPRING: 2 };
+      const order: Record<string, number> = { SPRING: 1, AUTUMN: 2 };
       return (order[a.semesterType ?? ''] ?? 0) - (order[b.semesterType ?? ''] ?? 0);
     }),
   );
 
   readonly filteredSemesters = computed(() =>
     this.hideCompleted()
-      ? this.sortedSemesters().filter((s) => !s.finished)
+      ? this.sortedSemesters().filter((s) => !this.isSemesterFinished(s.externalId))
       : this.sortedSemesters(),
   );
+
+  isSemesterFinished(semesterExternalId: string): boolean {
+    const courses = this.draftPlannedCourses().filter(
+      (d) => d.semesterExternalId === semesterExternalId,
+    );
+    if (courses.length === 0) return false;
+    return courses.every((d) => d.status === PlannedCourseResponse.courseStatus.COMPLETED);
+  }
+
   readonly currentSemesterId = computed(() => findCurrentSemester(this.semesters()));
 
   readonly totalCredits = computed(() =>
-    this.semesters().reduce(
-      (total, s) => total + calculateSemesterCredits(s.plannedCourses ?? []),
-      0,
-    ),
+    this.draftPlannedCourses().reduce((sum, d) => sum + (d.course.credits ?? 0), 0),
   );
 
   readonly totalRequired: Signal<number | null> = toSignal(
@@ -129,17 +164,144 @@ export class CurriculumPlanning {
 
   readonly moduleCredits: Signal<Map<string, number>> = computed(() => {
     const map = new Map<string, number>();
-
-    this.semesters().forEach((semester) => {
-      semester.plannedCourses?.forEach((pc) => {
-        if (pc.courseStatus === 'COMPLETED') {
-          const moduleId = pc.module.externalId;
-          const current = map.get(moduleId) ?? 0;
-          map.set(moduleId, current + pc.course.credits);
-        }
-      });
+    this.draftPlannedCourses().forEach((d) => {
+      if (d.status === PlannedCourseResponse.courseStatus.COMPLETED && d.module) {
+        const moduleId = d.module.externalId;
+        map.set(moduleId, (map.get(moduleId) ?? 0) + (d.course.credits ?? 0));
+      }
     });
-
     return map;
   });
+
+  getCourses(semester: SemesterResponse): CourseWithStatus[] {
+    return this.draftPlannedCourses()
+      .filter((d) => d.semesterExternalId === semester.externalId)
+      .map((d) => ({ ...d.course, courseStatus: d.status }));
+  }
+
+  getSemesterCredits(semesterExternalId: string): number {
+    return this.draftPlannedCourses()
+      .filter((d) => d.semesterExternalId === semesterExternalId)
+      .reduce((sum, d) => sum + (d.course.credits ?? 0), 0);
+  }
+
+  addCourse(course: CourseResponse): void {
+    const draft = this.draftPlannedCourses();
+    const matching = this.sortedSemesters().filter(
+      (s) =>
+        s.semesterType !== undefined &&
+        (s.semesterType as string) === (course.semesterType as string) &&
+        !draft.some(
+          (d) =>
+            d.semesterExternalId === s.externalId &&
+            d.course.versionExternalId === course.versionExternalId,
+        ),
+    );
+
+    if (matching.length === 0) {
+      this.notification.set({ kind: 'error', key: 'CurriculumPlanning.NoMatchingSemesters' });
+      return;
+    }
+
+    const data: AddCoursePlanDialogData = { course, semesters: matching };
+    const ref = this.dialog.open<string | undefined>(AddCoursePlanDialog, { data });
+    ref.closed.subscribe((semesterExternalId) => {
+      if (!semesterExternalId) return;
+      this.draftPlannedCourses.update((items) => [
+        ...items,
+        {
+          semesterExternalId,
+          course,
+          status: PlannedCourseResponse.courseStatus.PLANNED,
+        },
+      ]);
+    });
+  }
+
+  removeCourse(courseVersionExternalId: string, semesterExternalId: string): void {
+    this.draftPlannedCourses.update((items) =>
+      items.filter(
+        (d) =>
+          !(
+            d.semesterExternalId === semesterExternalId &&
+            d.course.versionExternalId === courseVersionExternalId
+          ),
+      ),
+    );
+  }
+
+  toggleCompleted(
+    courseVersionExternalId: string,
+    semesterExternalId: string,
+    checked: boolean,
+  ): void {
+    const next = checked
+      ? PlannedCourseResponse.courseStatus.COMPLETED
+      : PlannedCourseResponse.courseStatus.PLANNED;
+    this.draftPlannedCourses.update((items) =>
+      items.map((d) =>
+        d.semesterExternalId === semesterExternalId &&
+        d.course.versionExternalId === courseVersionExternalId
+          ? { ...d, status: next }
+          : d,
+      ),
+    );
+  }
+
+  save(): void {
+    if (!this.dirty() || this.saving()) return;
+    this.saving.set(true);
+    this.notification.set(null);
+
+    const requests: PlannedCourseRequest[] = this.draftPlannedCourses().map((d) => ({
+      semesterExternalId: d.semesterExternalId,
+      courseVersionExternalId: d.course.versionExternalId,
+      courseExternalId: d.course.oisExternalId,
+      status: d.status as unknown as PlannedCourseRequest.status,
+    }));
+
+    this.plannedCourseService
+      .setPlannedCourses(this.studyPlanExternalId, requests, this.user()?.externalId)
+      .pipe(
+        catchError(() => {
+          this.notification.set({ kind: 'error', key: 'CurriculumPlanning.SaveError' });
+          this.saving.set(false);
+          return of(null);
+        }),
+      )
+      .subscribe((result) => {
+        if (result === null) return;
+        this.saving.set(false);
+        this.notification.set({ kind: 'success', key: 'CurriculumPlanning.SaveSuccess' });
+        this.refreshTrigger.update((n) => n + 1);
+      });
+  }
+
+  dismissNotification(): void {
+    this.notification.set(null);
+  }
+
+  private flattenSemesters(semesters: SemesterResponse[]): DraftPlannedCourse[] {
+    return semesters.flatMap((s) =>
+      (s.plannedCourses ?? []).map((pc) => ({
+        externalId: pc.externalId,
+        semesterExternalId: s.externalId,
+        course: pc.course,
+        module: pc.module,
+        status: pc.courseStatus,
+      })),
+    );
+  }
+
+  private serializeDraft(items: DraftPlannedCourse[]): string {
+    return JSON.stringify(
+      [...items]
+        .map((d) => ({
+          s: d.semesterExternalId,
+          v: d.course.versionExternalId,
+          st: d.status,
+        }))
+        .sort((a, b) => (a.s + a.v).localeCompare(b.s + b.v)),
+    );
+  }
 }

--- a/frontend/src/app/features/curriculums/curriculum-planning/curriculum-planning.ts
+++ b/frontend/src/app/features/curriculums/curriculum-planning/curriculum-planning.ts
@@ -187,7 +187,7 @@ export class CurriculumPlanning {
 
   addCourse(course: CourseResponse): void {
     const draft = this.draftPlannedCourses();
-    const matching = this.sortedSemesters().filter(
+    const available = this.sortedSemesters().filter(
       (s) =>
         s.semesterType !== undefined &&
         (s.semesterType as string) === (course.semesterType as string) &&
@@ -198,12 +198,12 @@ export class CurriculumPlanning {
         ),
     );
 
-    if (matching.length === 0) {
-      this.notification.set({ kind: 'error', key: 'CurriculumPlanning.NoMatchingSemesters' });
+    if (available.length === 0) {
+      this.notification.set({ kind: 'error', key: 'CurriculumPlanning.NoAvailableSemester' });
       return;
     }
 
-    const data: AddCoursePlanDialogData = { course, semesters: matching };
+    const data: AddCoursePlanDialogData = { course, semesters: available };
     const ref = this.dialog.open<string | undefined>(AddCoursePlanDialog, { data });
     ref.closed.subscribe((semesterExternalId) => {
       if (!semesterExternalId) return;

--- a/frontend/src/app/shared/components/semester-badge/semester-badge.spec.ts
+++ b/frontend/src/app/shared/components/semester-badge/semester-badge.spec.ts
@@ -14,19 +14,19 @@ class TestHostComponent {
   semester = CourseResponse.semesterType.SPRING;
 }
 
-it('should display "S" label for SPRING', () => {
+it('should display "K" label for SPRING (kevad)', () => {
   const fixture = TestBed.createComponent(TestHostComponent);
   fixture.detectChanges();
 
   const chip = fixture.nativeElement.querySelector('mat-chip');
-  expect(chip.textContent.trim()).toBe('S');
+  expect(chip.textContent.trim()).toBe('K');
 });
 
-it('should display "K" label for AUTUMN', () => {
+it('should display "S" label for AUTUMN (sügis)', () => {
   const fixture = TestBed.createComponent(TestHostComponent);
   fixture.componentInstance.semester = CourseResponse.semesterType.AUTUMN;
   fixture.detectChanges();
 
   const chip = fixture.nativeElement.querySelector('mat-chip');
-  expect(chip.textContent.trim()).toBe('K');
+  expect(chip.textContent.trim()).toBe('S');
 });

--- a/frontend/src/app/shared/components/semester-badge/semester-badge.ts
+++ b/frontend/src/app/shared/components/semester-badge/semester-badge.ts
@@ -3,8 +3,8 @@ import { MatChipsModule } from '@angular/material/chips';
 import { CourseResponse } from '@/client';
 
 const SEMESTER_MAP: Record<CourseResponse.semesterType, { label: string; color: string }> = {
-  [CourseResponse.semesterType.SPRING]: { label: 'S', color: '#85DC75' },
-  [CourseResponse.semesterType.AUTUMN]: { label: 'K', color: '#CAE0FF' },
+  [CourseResponse.semesterType.SPRING]: { label: 'K', color: '#85DC75' },
+  [CourseResponse.semesterType.AUTUMN]: { label: 'S', color: '#CAE0FF' },
 };
 
 @Component({

--- a/frontend/src/assets/i18n/ee.json
+++ b/frontend/src/assets/i18n/ee.json
@@ -14,10 +14,13 @@
   "Common": {
     "WorkInProgress": "Töös",
     "Save": "Salvesta",
+    "Saving": "Salvestan...",
     "AddNew": "Lisa uus",
     "Autumn": "Sügis",
     "Spring": "Kevad",
-    "Edit": "Muuda"
+    "Edit": "Muuda",
+    "Close": "Sulge",
+    "Remove": "Eemalda"
   },
   "Dashboard": {
     "Title": "Avaleht"
@@ -56,6 +59,14 @@
     "Modules": "Moodulite täituvus",
     "RequiredCredits": "Kohustusliku ained",
     "OptionalCredits": "Valikained",
-    "NoModulesNotification": "Hetkel ei leitud ühtegi moodulit"
+    "NoModulesNotification": "Hetkel ei leitud ühtegi moodulit",
+    "AddCourseModalLabel": "Lisa aine modal",
+    "Add": "Lisa",
+    "IntoSemester": "Semestrisse",
+    "AddToPlan": "Lisa aine plaani",
+    "NoMatchingSemesters": "Selle aine jaoks puudub sobiv semester",
+    "SaveSuccess": "Plaan salvestatud",
+    "SaveError": "Plaani salvestamine ebaõnnestus",
+    "RemoveCourse": "Eemalda aine"
   }
 }

--- a/frontend/src/assets/i18n/ee.json
+++ b/frontend/src/assets/i18n/ee.json
@@ -64,7 +64,7 @@
     "Add": "Lisa",
     "IntoSemester": "Semestrisse",
     "AddToPlan": "Lisa aine plaani",
-    "NoAvailableSemester": "Sellele ainele ei leidu sobivat semestrit",
+    "NoAvailableSemester": "See aine on juba kõikidesse sobivatesse semestritesse lisatud",
     "SaveSuccess": "Plaan salvestatud",
     "SaveError": "Plaani salvestamine ebaõnnestus",
     "RemoveCourse": "Eemalda aine"

--- a/frontend/src/assets/i18n/ee.json
+++ b/frontend/src/assets/i18n/ee.json
@@ -64,7 +64,7 @@
     "Add": "Lisa",
     "IntoSemester": "Semestrisse",
     "AddToPlan": "Lisa aine plaani",
-    "NoMatchingSemesters": "Selle aine jaoks puudub sobiv semester",
+    "NoAvailableSemester": "Sellele ainele ei leidu sobivat semestrit",
     "SaveSuccess": "Plaan salvestatud",
     "SaveError": "Plaani salvestamine ebaõnnestus",
     "RemoveCourse": "Eemalda aine"

--- a/frontend/src/main.server.ts
+++ b/frontend/src/main.server.ts
@@ -1,6 +1,9 @@
 import { BootstrapContext, bootstrapApplication } from '@angular/platform-browser';
 import { App } from './app/app';
 import { config } from './app/app.config.server';
+import { OpenAPI } from '@/client';
+
+OpenAPI.BASE = process.env['BACKEND_URL'] ?? 'http://localhost:8080';
 
 const bootstrap = (context: BootstrapContext) => bootstrapApplication(App, config, context);
 

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -3,6 +3,6 @@ import { appConfig } from './app/app.config';
 import { App } from './app/app';
 import { OpenAPI } from '@/client';
 
-OpenAPI.BASE = '';
+OpenAPI.BASE = 'http://localhost:8080';
 
 bootstrapApplication(App, appConfig).catch((err) => console.error(err));

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -41,4 +41,9 @@ app-root {
   --color-page-background: #f7fafd;
   --color-sidebar-text: #1f2a44;
   --color-sidebar-subtext: #4b5a76;
+  --color-success-background: #e8f5ed;
+  --color-success-text: #1f6b3a;
+  --color-error-background: #fdecec;
+  --color-error-text: #a92626;
+  --color-overlay-shadow: rgba(0, 0, 0, 0.16);
 }


### PR DESCRIPTION
## Context
 - Add courses from the catalog to a semester through a small modal
  - Remove courses with the × icon
  - Mark a course done with the checkbox
  - Save sends one PUT that replaces the whole plan for the study plan
  - Õppekavad list now shows the right completed credits after save (was stuck on 0/120)
  - The modal only lists semesters where the course actually fits (right type, not already there), so there's no need for tooltips or error messages
  - A semester turns "done" automatically once every course in it is marked completed; if you uncheck one, the strikethrough goes away straight away
  - Empty semesters start closed, ones with courses start open
  - Added 5 more semesters to the seed so you can actually see a timeline


## How it looks like
 
<img width="2510" height="1228" alt="image" src="https://github.com/user-attachments/assets/b463cddc-2bc4-4ea9-a725-0f3b68d2fcee" />
